### PR TITLE
RCA-17: Передача Parcelable-объекта между экранами

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    id("kotlin-parcelize")
 }
 
 android {

--- a/app/src/main/java/com/example/recipecomposeapp/RecipesApp.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/RecipesApp.kt
@@ -12,9 +12,12 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.example.recipecomposeapp.core.ui.navigation.BottomNavigation
 import com.example.recipecomposeapp.core.ui.navigation.Destination
+import com.example.recipecomposeapp.core.ui.navigation.KEY_RECIPE_OBJECT
 import com.example.recipecomposeapp.ui.categories.CategoriesScreen
 import com.example.recipecomposeapp.ui.favorites.FavoritesScreen
+import com.example.recipecomposeapp.ui.recipes.RecipeDetailsScreen
 import com.example.recipecomposeapp.ui.recipes.RecipesScreen
+import com.example.recipecomposeapp.ui.recipes.model.RecipeUiModel
 import com.example.recipecomposeapp.ui.theme.RecipesAppTheme
 
 @Composable
@@ -38,10 +41,11 @@ fun RecipesApp(darkTheme: Boolean = isSystemInDarkTheme()) {
                     },
                     onCategoriesClick = {
                         navController.navigate(Destination.Categories.route) {
-                            popUpTo(Destination.Categories.route) {
-                                inclusive  = false
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
                             }
                             launchSingleTop = true
+                            restoreState = true
                         }
                     }
                 )
@@ -71,8 +75,29 @@ fun RecipesApp(darkTheme: Boolean = isSystemInDarkTheme()) {
                         contentPadding = innerPadding,
                         categoryId = categoryId,
                         categoryTitle = "",
-                        onRecipeClick = { }
+                        onRecipeClick = { recipeId, recipe ->
+                            navController.currentBackStackEntry?.savedStateHandle?.set(
+                                KEY_RECIPE_OBJECT,
+                                recipe
+                            )
+                            navController.navigate(Destination.RecipeDetails.createRoute(recipeId))
+                        }
                     )
+                }
+                composable(
+                    route = Destination.RecipeDetails.route,
+                    arguments = listOf(navArgument("recipeId") { type = NavType.IntType })
+                ) {
+                    val recipe =
+                        navController.previousBackStackEntry?.savedStateHandle?.get<RecipeUiModel>(
+                            KEY_RECIPE_OBJECT
+                        )
+                    if (recipe != null) {
+                        RecipeDetailsScreen(
+                            contentPadding = innerPadding,
+                            recipe = recipe,
+                        )
+                    }
                 }
                 composable(
                     route = Destination.Favorites.route

--- a/app/src/main/java/com/example/recipecomposeapp/core/AppAsyncImage.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/core/AppAsyncImage.kt
@@ -1,6 +1,5 @@
 package com.example.recipecomposeapp.core
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,8 +15,7 @@ import com.example.recipecomposeapp.R
 
 @Composable
 fun AppAsyncImage(
-    imageUrl: String,
-    @DrawableRes previewRes: Int,
+    model: Any?,
     contentDescription: String,
     modifier: Modifier = Modifier,
     placeholder: Painter = painterResource(R.drawable.img_placeholder),
@@ -27,16 +25,25 @@ fun AppAsyncImage(
     val isPreview = LocalInspectionMode.current
 
     if (isPreview) {
-        Image(
-            painter = painterResource(previewRes),
-            contentDescription = contentDescription,
-            modifier = modifier,
-            contentScale = contentScale,
-        )
+        if (model is Int) {
+            Image(
+                painter = painterResource(model),
+                contentDescription = contentDescription,
+                modifier = modifier,
+                contentScale = contentScale,
+            )
+        } else {
+            Image(
+                painter = painterResource(R.drawable.preview_burger),
+                contentDescription = contentDescription,
+                modifier = modifier,
+                contentScale = contentScale,
+            )
+        }
     } else {
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
-                .data(imageUrl)
+                .data(model)
                 .crossfade(true)
                 .build(),
             contentDescription = contentDescription,

--- a/app/src/main/java/com/example/recipecomposeapp/core/ui/ScreenHeader.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/core/ui/ScreenHeader.kt
@@ -1,7 +1,5 @@
 package com.example.recipecomposeapp.core.ui
 
-import androidx.annotation.DrawableRes
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,13 +15,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.example.recipecomposeapp.core.AppAsyncImage
 
 @Composable
 fun ScreenHeader(
     title: String,
-    @DrawableRes backgroundImageRes: Int,
+    backgroundImageModel: Any?,
     modifier: Modifier = Modifier,
     isFavorite: Boolean? = null,
     onFavoriteClick: () -> Unit = {}
@@ -33,8 +31,8 @@ fun ScreenHeader(
             .fillMaxWidth()
             .height(224.dp)
     ) {
-        Image(
-            painter = painterResource(backgroundImageRes),
+        AppAsyncImage(
+            model = backgroundImageModel,
             contentDescription = title,
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Crop
@@ -47,7 +45,7 @@ fun ScreenHeader(
             Surface(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
-                    .padding(start = 16.dp, bottom = 16.dp),
+                    .padding(start = 16.dp, bottom = 16.dp, end = 16.dp),
                 shape = RoundedCornerShape(8.dp),
                 color = MaterialTheme.colorScheme.background
             ) {

--- a/app/src/main/java/com/example/recipecomposeapp/core/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/core/ui/navigation/Destination.kt
@@ -11,6 +11,8 @@ sealed class Destination(val route: String) {
     }
 
     object RecipeDetails: Destination("recipe_details/{recipeId}") {
-        fun createRoute(recipeId: Int) = "recipe_details/{$recipeId}"
+        fun createRoute(recipeId: Int) = "recipe_details/$recipeId"
     }
 }
+
+const val KEY_RECIPE_OBJECT = "recipe_object"

--- a/app/src/main/java/com/example/recipecomposeapp/ui/categories/CategoriesScreen.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/ui/categories/CategoriesScreen.kt
@@ -39,7 +39,7 @@ fun CategoriesScreen(
     Column(modifier = Modifier.fillMaxSize()) {
         ScreenHeader(
             title = "Категория",
-            backgroundImageRes = R.drawable.bcg_categories,
+            backgroundImageModel = R.drawable.bcg_categories,
         )
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),

--- a/app/src/main/java/com/example/recipecomposeapp/ui/categories/components/CategoryItem.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/ui/categories/components/CategoryItem.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.recipecomposeapp.R
 import com.example.recipecomposeapp.core.AppAsyncImage
 import com.example.recipecomposeapp.ui.categories.model.CategoryUiModel
 import com.example.recipecomposeapp.ui.theme.RecipesAppTheme
@@ -39,8 +38,7 @@ fun CategoryItem(
     ) {
         Column {
             AppAsyncImage(
-                imageUrl = category.imageUrl,
-                previewRes = R.drawable.preview_burger,
+                model = category.imageUrl,
                 contentDescription = category.title,
                 modifier = Modifier
                     .height(130.dp)
@@ -74,7 +72,7 @@ fun CategoryItemPreview() {
                 id = 0,
                 title = "Бургеры",
                 description = "Рецепты всех популярных видов бургеров",
-                imageUrl = ""
+                imageUrl = "",
             )
         )
     }

--- a/app/src/main/java/com/example/recipecomposeapp/ui/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/ui/favorites/FavoritesScreen.kt
@@ -20,7 +20,7 @@ fun FavoritesScreen(contentPadding: PaddingValues) {
     Column(modifier = Modifier.fillMaxSize()) {
         ScreenHeader(
             title = "Избранное",
-            backgroundImageRes = R.drawable.bcg_favorites
+            backgroundImageModel = R.drawable.bcg_favorites
         )
         Box(
             modifier = Modifier
@@ -33,7 +33,10 @@ fun FavoritesScreen(contentPadding: PaddingValues) {
     }
 }
 
-@Preview
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+)
 @Composable
 fun FavoritesScreenPreview() {
     RecipesAppTheme {

--- a/app/src/main/java/com/example/recipecomposeapp/ui/recipes/RecipeDetailsScreen.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/ui/recipes/RecipeDetailsScreen.kt
@@ -1,0 +1,94 @@
+package com.example.recipecomposeapp.ui.recipes
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.recipecomposeapp.core.ui.ScreenHeader
+import com.example.recipecomposeapp.ui.recipes.model.IngredientUiModel
+import com.example.recipecomposeapp.ui.recipes.model.RecipeUiModel
+import com.example.recipecomposeapp.ui.theme.RecipesAppTheme
+
+@Composable
+fun RecipeDetailsScreen(
+    contentPadding: PaddingValues,
+    recipe: RecipeUiModel,
+) {
+    val bottomPadding = contentPadding.calculateBottomPadding()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        ScreenHeader(
+            title = recipe.title,
+            backgroundImageModel = recipe.imageUrl,
+        )
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                top = 16.dp,
+                end = 16.dp,
+                bottom = 16.dp + bottomPadding),
+        ) {
+            item {
+                Text(
+                    "Ингредиенты".uppercase(),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.displayLarge,
+                )
+            }
+            items(recipe.ingredients) { ingredient ->
+                Text("${ingredient.name}: ${ingredient.amount}")
+            }
+            item {
+                Text(
+                    "Способ приготовления".uppercase(),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.displayLarge,
+                )
+            }
+            items(recipe.method) { step ->
+                Text(step)
+            }
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    showSystemUi = true,
+)
+@Composable
+fun RecipeDetailsScreenPreview() {
+    RecipesAppTheme {
+        RecipeDetailsScreen(
+            contentPadding = PaddingValues(0.dp),
+            recipe = RecipeUiModel(
+                id = 0,
+                title = "Классический бургер с говядиной",
+                imageUrl = "",
+                isFavorite = false,
+
+                ingredients = listOf(
+                    IngredientUiModel("говяжий фарш", "0.5 кг"),
+                    IngredientUiModel("луковица, мелко нарезанная", "1 шт"),
+                    IngredientUiModel("чеснок, измельченный", "2 зубч")
+                ),
+
+                method = listOf(
+                    "1. В глубокой миске смешайте говяжий фарш, лук, чеснок, соль и перец. Разделите фарш на 4 равные части и сформируйте котлеты.",
+                    "2. Разогрейте сковороду на среднем огне. Обжаривайте котлеты с каждой стороны в течение 4-5 минут или до желаемой степени прожарки.",
+                    "3. В то время как котлеты готовятся, подготовьте булочки. Разрежьте их пополам и обжарьте на сковороде до золотистой корочки.",
+                )
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/recipecomposeapp/ui/recipes/RecipesScreen.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/ui/recipes/RecipesScreen.kt
@@ -33,7 +33,7 @@ fun RecipesScreen(
     contentPadding: PaddingValues,
     categoryId: Int?,
     categoryTitle: String,
-    onRecipeClick: (Int) -> Unit,
+    onRecipeClick: (Int, RecipeUiModel) -> Unit,
 ) {
     val bottomPadding = contentPadding.calculateBottomPadding()
 
@@ -58,7 +58,7 @@ fun RecipesScreen(
     Column(modifier = Modifier.fillMaxSize()) {
         ScreenHeader(
             title = "Рецепты",
-            backgroundImageRes = R.drawable.bcg_categories
+            backgroundImageModel = R.drawable.bcg_categories
         )
         if (isLoading) {
             Box(
@@ -105,7 +105,7 @@ fun RecipesScreenPreview() {
             contentPadding = PaddingValues(0.dp),
             categoryId = 0,
             categoryTitle = "Рецепты",
-            onRecipeClick = {}
+            onRecipeClick = { _, _ -> }
         )
     }
 }

--- a/app/src/main/java/com/example/recipecomposeapp/ui/recipes/components/RecipeItem.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/ui/recipes/components/RecipeItem.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.example.recipecomposeapp.R
 import com.example.recipecomposeapp.core.AppAsyncImage
 import com.example.recipecomposeapp.ui.recipes.model.RecipeUiModel
 import com.example.recipecomposeapp.ui.theme.RecipesAppTheme
@@ -23,11 +22,11 @@ import com.example.recipecomposeapp.ui.theme.RecipesAppTheme
 fun RecipeItem(
     recipe: RecipeUiModel,
     modifier: Modifier = Modifier,
-    onRecipeClick: (Int) -> Unit = { _, -> },
+    onRecipeClick: (Int, RecipeUiModel) -> Unit = { _, _ -> },
     ) {
 
     Card(
-        modifier = modifier.clickable{ onRecipeClick(recipe.id) },
+        modifier = modifier.clickable{ onRecipeClick(recipe.id, recipe) },
         shape = RoundedCornerShape(8.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface
@@ -38,8 +37,7 @@ fun RecipeItem(
     ) {
         Column {
             AppAsyncImage(
-                imageUrl = recipe.imageUrl,
-                previewRes = R.drawable.preview_burger,
+                model = recipe.imageUrl,
                 contentDescription = recipe.title,
                 modifier = Modifier
                     .height(100.dp)

--- a/app/src/main/java/com/example/recipecomposeapp/ui/recipes/model/IngredientUiModel.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/ui/recipes/model/IngredientUiModel.kt
@@ -1,13 +1,16 @@
 package com.example.recipecomposeapp.ui.recipes.model
 
+import android.os.Parcelable
 import androidx.compose.runtime.Immutable
 import com.example.recipecomposeapp.data.model.IngredientDto
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 @Immutable
 data class IngredientUiModel(
     val name: String,
     val amount: String,
-)
+) : Parcelable
 
 fun IngredientDto.toUiModel() = IngredientUiModel(
     name = description,

--- a/app/src/main/java/com/example/recipecomposeapp/ui/recipes/model/RecipeUiModel.kt
+++ b/app/src/main/java/com/example/recipecomposeapp/ui/recipes/model/RecipeUiModel.kt
@@ -1,9 +1,12 @@
 package com.example.recipecomposeapp.ui.recipes.model
 
+import android.os.Parcelable
 import androidx.compose.runtime.Immutable
 import com.example.recipecomposeapp.core.Constants
 import com.example.recipecomposeapp.data.model.RecipeDto
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 @Immutable
 data class RecipeUiModel(
     val id: Int,
@@ -12,7 +15,7 @@ data class RecipeUiModel(
     val ingredients: List<IngredientUiModel>,
     val method: List<String>,
     val isFavorite: Boolean,
-)
+) : Parcelable
 
 fun RecipeDto.toUiModel() = RecipeUiModel(
     id = id,


### PR DESCRIPTION
В процессе выполнения задачи, потребовалось доработать существующие компоненты для универсальности:

`AppAsyncImage` теперь поддерживает любые типы моделей изображения

`ScreenHeader` также изменил параметр изображения для поддержки динамических изображений рецептов и заменил Image на AppAsyncImage.

Заметил баг и не разобрался: У ScreenHeader при переносе title на две строки surface растягивается до правого края. Я же хотел бы, чтобы он растягивался по размеру самой большей из переносимых строк. Помню на xml вёрстке была подобная проблема, так и оставил её